### PR TITLE
Handle case when manually tagged users are the same as random

### DIFF
--- a/src/Repository/AuthorRepository.php
+++ b/src/Repository/AuthorRepository.php
@@ -30,8 +30,9 @@ class AuthorRepository extends ServiceEntityRepository
         $ignoredAuthorIds = $this->getAuthorsThatNeedToBeIgnored($review);
         $potentialAuthors = $this->fetchPotentialAuthors(
             $allowedAuthorIds,
-            $ignoredAuthorIds,
+            array_merge($ignoredAuthorIds, $requiredAuthorIds),
         );
+
         $requiredAuthors = $this->findBy(['id' => $requiredAuthorIds]);
         $selectedAuthors = array_merge($requiredAuthors, $potentialAuthors);
 


### PR DESCRIPTION
Whenever you tag a specific user, e.g.

`@review/backend TechLead`

The bot attempts to select an additional random reviewer. If that reviewer is in the `@review/backend` group, a bug occurs.