### PR TITLE
Avoid slack spam on blacklist refresh

### DIFF
--- a/src/Entity/AuthorBlacklist.php
+++ b/src/Entity/AuthorBlacklist.php
@@ -23,6 +23,11 @@ class AuthorBlacklist
      */
     private $author;
 
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $banned;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -36,6 +41,18 @@ class AuthorBlacklist
     public function setAuthor(Author $author): self
     {
         $this->author = $author;
+
+        return $this;
+    }
+
+    public function isBanned(): bool
+    {
+        return $this->banned;
+    }
+
+    public function setBanned($banned): self
+    {
+        $this->banned = $banned;
 
         return $this;
     }

--- a/src/Migrations/Version20211018073228.php
+++ b/src/Migrations/Version20211018073228.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211018073228 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE author_blacklist ADD banned TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE author_blacklist DROP banned');
+    }
+}

--- a/src/Service/ChatService.php
+++ b/src/Service/ChatService.php
@@ -112,7 +112,7 @@ class ChatService
         return $chatUsername;
     }
 
-    protected function postMessage(string $channel, string $text): void
+    public function postMessage(string $channel, string $text): void
     {
         try {
             $this->logger->warning('Chat post message', ['text' => $text]);


### PR DESCRIPTION
If the user has been deleted from slack - we should permanently ban him